### PR TITLE
Updating the version number for WP 6.3 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 # Change log
 
+## [[1.2.7]](https://github.com/lightspeeddevelopment/to-team/releases/tag/1.2.7) - 2023-08-09
+
+### Security
+- General testing to ensure compatibility with latest WordPress version (6.3).
+
 ## [[1.2.6]](https://github.com/lightspeeddevelopment/to-team/releases/tag/1.2.6) - 2023-04-20
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "to-team",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Tour Operators add-on for LSX",
   "main": "gulpfile.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: feedmymedia, lightspeedwp, eleshar, krugazul, jacquesvdh, ignusver
 Donate link: https://lsdev.biz/lsx/donate/
 Tags: lsx, tour operator, team, team members, our team
 Requires at least: 5.0
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 7.4
-Stable tag: 1.2.6
+Stable tag: 1.2.7
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 

--- a/to-team.php
+++ b/to-team.php
@@ -3,7 +3,7 @@
  * Plugin Name:	LSX Tour Operator Team
  * Plugin URI:	https://www.lsdev.biz/product/tour-operator-team/
  * Description:	Real peoples' faces go a long way to building trust with your clients. The Team Extension allows your business's staff to be added as Team Members with their own profile which can be associated with specific destinations and tours.
- * Version:     1.2.6
+ * Version:     1.2.7
  * Author:      LightSpeed
  * Author URI: 	https://www.lsdev.biz/
  * License: 	GPL3+
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'LSX_TO_TEAM_PATH', plugin_dir_path( __FILE__ ) );
 define( 'LSX_TO_TEAM_CORE', __FILE__ );
 define( 'LSX_TO_TEAM_URL', plugin_dir_url( __FILE__ ) );
-define( 'LSX_TO_TEAM_VER', '1.2.6' );
+define( 'LSX_TO_TEAM_VER', '1.2.7' );
 
 if ( ! defined( 'TEAM_ARCHIVE_URL' ) ) {
 	define( 'TEAM_ARCHIVE_URL', 'team-members' );


### PR DESCRIPTION
### Description
- General testing to ensure compatibility with latest WordPress version (6.3).
- Updating the version number and stable tag